### PR TITLE
🌟(#13 ) [Fix] 레이드 체력 0 되면 이미지 사라짐

### DIFF
--- a/src/component/raid/RaidBattle.jsx
+++ b/src/component/raid/RaidBattle.jsx
@@ -88,8 +88,10 @@ function RaidBattle() {
                 return slimeWounded;
             } else if (ratio > 0.25) {
                 return slimeHalf;
-            } else {
+            } else if (ratio > 0 ) {
                 return slimeWeak;
+            } else {
+                return null;
             }
         } else {
             if (ratio > 0.75) {
@@ -98,8 +100,10 @@ function RaidBattle() {
                 return kingWounded;
             } else if (ratio > 0.25) {
                 return kingHalf;
-            } else {
+            } else if (ratio > 0 ) {
                 return kingWeak;
+            } else {
+                return null;
             }
         }
             


### PR DESCRIPTION
## 🌟(#13 ) [Fix] 레이드 체력 0 되면 이미지 사라짐


## ✍️내용
- 레이드 화면에서 몬스터의 체력이 0이 되면 몬스터 이미지가 사라짐
- 

## 📸스크린샷


## 🎈참고사항